### PR TITLE
Persist share and block dates.

### DIFF
--- a/lib/shareProcessor.js
+++ b/lib/shareProcessor.js
@@ -44,8 +44,8 @@ var ShareProcessor = module.exports = function ShareProcessor(config, logger){
 
     function persistShare(db, share){
         db.query(
-            'INSERT INTO shares(from_group, to_group, pool_diff, share_diff, worker, found_block) VALUES($1, $2, $3, $4, $5, $6) RETURNING id',
-            [share.job.fromGroup, share.job.toGroup, share.difficulty, share.shareDiff, share.workerAddress, share.foundBlock],
+            'INSERT INTO shares(from_group, to_group, pool_diff, share_diff, worker, found_block, created_date, modified_date) VALUES($1, $2, $3, $4, $5, $6, $7, $8) RETURNING id',
+            [share.job.fromGroup, share.job.toGroup, share.difficulty, share.shareDiff, share.workerAddress, share.foundBlock, new Date(), new Date()],
             function(error, result){
                 if (error) {
                     logger.error('Persist share error: ' + error);
@@ -55,8 +55,9 @@ var ShareProcessor = module.exports = function ShareProcessor(config, logger){
                 if (share.foundBlock){
                     var shareId = result.rows[0].id;
                     db.query(
-                        'INSERT INTO blocks(share_id, from_group, to_group, block_hash, worker) VALUES($1, $2, $3, $4, $5)',
-                        [shareId, share.job.fromGroup, share.job.toGroup, share.blockHash, share.workerAddress],
+                        'INSERT INTO blocks(share_id, from_group, to_group, block_hash, worker, created_date, modified_date) VALUES($1, $2, $3, $4, $5, $6, $7)',
+                        [shareId, share.job.fromGroup, share.job.toGroup, share.blockHash, share.workerAddress, new Date(), new Date()],
+
                         function(error, _){
                             if (error) logger.error('Persist block error: ' + error);
                         }


### PR DESCRIPTION
SQL does not include values for `created_date`	 and `modified_date` thus these fields are empty for all shares and blocks.
Here is the patch.