### PR TITLE
pass block hash and block notification to event

### DIFF
--- a/lib/pool.js
+++ b/lib/pool.js
@@ -98,6 +98,8 @@ var pool = module.exports = function pool(config, logger){
                 toGroup: job.toGroup,
                 pool_difficulty: shareData.difficulty,
                 share_difficulty: shareData.shareDiff,
+                block_hash: shareData.blockHash,
+                found_block: shareData.foundBlock,
                 ip: shareData.ip
             }))
             _this.shareProcessor.handleShare(shareData);


### PR DESCRIPTION
Include "block_hash" and "found_block" attributes in share event.