### PR TITLE
add proxy protocol support

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ configs explanation:
     "pool": {
         "port": 20032,                  // port which the server bind
         "diff": 64,                     // init difficulty
-
+        "proxyProtocol": false,         // enable it to get real client IPs if you are behind a reverse proxy that uses Proxy Protocol v1  
         "varDiff": {
             "minDiff": 16,              // minimum difficulty
             "maxDiff": 4096,            // maximum difficulty

--- a/composePoolConfig.json
+++ b/composePoolConfig.json
@@ -21,6 +21,7 @@
     "pool": {
         "port": 20032,
         "diff": 1,
+        "proxyProtocol": false,
 
         "varDiff": {
             "minDiff": 1,

--- a/lib/config.json
+++ b/lib/config.json
@@ -20,6 +20,7 @@
     "diff1TargetNumZero": 30,
     "pool": {
         "port": 20032,
+        "proxyProtocol": false,
         "diff": 1,
 
         "varDiff": {

--- a/lib/stratum.js
+++ b/lib/stratum.js
@@ -348,7 +348,13 @@ var StratumServer = exports.Server = function StratumServer(config){
             }, 1000 * config.banning.purgeInterval);
         }
 
-        _this.server = net.createServer({allowHalfOpen: false}, function(socket) {
+        var serverFactory = net.createServer;
+        if (config.pool.proxyProtocol) {
+            const proxiedNet = require('findhit-proxywrap').proxy(net);
+            serverFactory = proxiedNet.createServer;
+        }
+
+        _this.server = serverFactory({allowHalfOpen: false}, function(socket) {
             _this.handleNewClient(socket);
         }).listen(config.pool.port, function() {
             _this.emit('started');

--- a/lib/stratum.js
+++ b/lib/stratum.js
@@ -350,6 +350,7 @@ var StratumServer = exports.Server = function StratumServer(config){
 
         var serverFactory = net.createServer;
         if (config.pool.proxyProtocol) {
+            console.log('will use proxy protocol')
             const proxiedNet = require('findhit-proxywrap').proxy(net);
             serverFactory = proxiedNet.createServer;
         }

--- a/lib/stratum.js
+++ b/lib/stratum.js
@@ -350,7 +350,6 @@ var StratumServer = exports.Server = function StratumServer(config){
 
         var serverFactory = net.createServer;
         if (config.pool.proxyProtocol) {
-            console.log('will use proxy protocol')
             const proxiedNet = require('findhit-proxywrap').proxy(net);
             serverFactory = proxiedNet.createServer;
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
                 "bignum": "0.13.1",
                 "binary-parser": "2.0.2",
                 "blake3": "2.1.7",
+                "findhit-proxywrap": "^0.3.13",
                 "ioredis": "^4.28.2",
                 "pg": "^8.7.1",
                 "winston": "^3.3.3",
@@ -534,6 +535,17 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/findhit-proxywrap": {
+            "version": "0.3.13",
+            "resolved": "https://registry.npmjs.org/findhit-proxywrap/-/findhit-proxywrap-0.3.13.tgz",
+            "integrity": "sha512-gI1KV7yCuMHtveiWbQUJZheNOukScz+15MTtrH/MK5RJ77JjYeJ1DegUfkBnlPvDx5NhZESl48zE/MwpWZ1LXQ==",
+            "dependencies": {
+                "lodash": "^4.17.21"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
         "node_modules/flat": {
             "version": "5.0.2",
             "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
@@ -839,8 +851,7 @@
         "node_modules/lodash": {
             "version": "4.17.21",
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-            "dev": true
+            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
         },
         "node_modules/lodash.defaults": {
             "version": "4.2.0",
@@ -2082,6 +2093,14 @@
                 "path-exists": "^4.0.0"
             }
         },
+        "findhit-proxywrap": {
+            "version": "0.3.13",
+            "resolved": "https://registry.npmjs.org/findhit-proxywrap/-/findhit-proxywrap-0.3.13.tgz",
+            "integrity": "sha512-gI1KV7yCuMHtveiWbQUJZheNOukScz+15MTtrH/MK5RJ77JjYeJ1DegUfkBnlPvDx5NhZESl48zE/MwpWZ1LXQ==",
+            "requires": {
+                "lodash": "^4.17.21"
+            }
+        },
         "flat": {
             "version": "5.0.2",
             "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
@@ -2300,8 +2319,7 @@
         "lodash": {
             "version": "4.17.21",
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-            "dev": true
+            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
         },
         "lodash.defaults": {
             "version": "4.2.0",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
         "bignum": "0.13.1",
         "binary-parser": "2.0.2",
         "blake3": "2.1.7",
+        "findhit-proxywrap": "^0.3.13",
         "ioredis": "^4.28.2",
         "pg": "^8.7.1",
         "winston": "^3.3.3",


### PR DESCRIPTION
This PR adds an option to get a real client IP when running behind a reverse proxy or load balancer that uses Proxy Protocol v1.
A common use case: a pool is running behind traefik's TCP proxy.

Usage:
1. set `"pool.proxyProtocol": true` in config file

You can also run the pool under TLS protected ingress server.