### PR TITLE
Allow multiple instances of the pool to share the same redis

### DIFF
--- a/lib/shareProcessor.js
+++ b/lib/shareProcessor.js
@@ -87,33 +87,55 @@ var ShareProcessor = module.exports = function ShareProcessor(config, logger){
         return fromGroup + ':' + toGroup + ':shares:' + blockHash;
     }
 
+    this.shareCacheKey = function(fromGroup, toGroup){
+        return fromGroup + ':' + toGroup + ':sharecache';
+    }
+
     var pendingBlocksKey = 'pendingBlocks';
     var foundBlocksKey = 'foundBlocks';
     var hashrateKey = 'hashrate';
     var balancesKey = 'balances';
 
     this._handleShare = function(share){
-        var redisTx = _this.redisClient.multi();
-        var currentMs = Date.now();
         var fromGroup = share.job.fromGroup;
         var toGroup = share.job.toGroup;
+        var blockHash = share.blockHash;
         var currentRound = _this.currentRoundKey(fromGroup, toGroup);
-        redisTx.hincrbyfloat(currentRound, share.workerAddress, share.difficulty);
+        var cacheKey = _this.shareCacheKey(fromGroup, toGroup);
 
-        var currentTs = Math.floor(currentMs / 1000);
-        redisTx.zadd(hashrateKey, currentTs, [fromGroup, toGroup, share.worker, share.difficulty, currentMs].join(':'));
+        _this.redisClient.sadd(cacheKey, blockHash, function(error, result){
+            if (error){
+                logger.error('Check share duplicated failed, error: ' + error);
+                callback(error);
+                return;
+            }
 
-        if (share.foundBlock){
-            var blockHash = share.blockHash;
-            var newKey = _this.roundKey(fromGroup, toGroup, blockHash);
-            var blockWithTs = blockHash + ':' + currentMs.toString();
+            if (result === 0){
+                logger.error('Ignore duplicated share');
+                callback('Duplicated share');
+                return;
+            }
 
-            redisTx.rename(currentRound, newKey);
-            redisTx.sadd(pendingBlocksKey, blockWithTs);
-            redisTx.hset(foundBlocksKey, blockHash, share.workerAddress)
-        }
-        redisTx.exec(function(error, _){
-            if (error) logger.error('Handle share failed, error: ' + error);
+            var redisTx = _this.redisClient.multi();
+            var currentMs = Date.now();
+            redisTx.hincrbyfloat(currentRound, share.workerAddress, share.difficulty);
+
+            var currentTs = Math.floor(currentMs / 1000);
+            redisTx.zadd(hashrateKey, currentTs, [fromGroup, toGroup, share.worker, share.difficulty, currentMs].join(':'));
+
+            if (share.foundBlock){
+                var blockHash = share.blockHash;
+                var newKey = _this.roundKey(fromGroup, toGroup, blockHash);
+                var blockWithTs = blockHash + ':' + currentMs.toString();
+
+                redisTx.renamenx(currentRound, newKey);
+                redisTx.sadd(pendingBlocksKey, blockWithTs);
+                redisTx.hsetnx(foundBlocksKey, blockHash, share.workerAddress)
+                redisTx.del(cacheKey);
+            }
+            redisTx.exec(function(error, _){
+                if (error) logger.error('Handle share failed, error: ' + error);
+            });
         });
     }
 


### PR DESCRIPTION
Adding a new share has been put in a pipeline, with a _lock_ to allow multiple pools to share the same redis backend while avoiding share collision in case of concurrency.